### PR TITLE
feat: add volume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For example:
 ```js
 {
   "onStart": "<path(s)-to-audio>",
-  "onStartThreshold": 3,
+  "onStartThreshold": 10,
   "onSuitePass": "<path(s)-to-audio>",
   "onSuiteFailure": "<path(s)-to-audio>"
 }
@@ -72,7 +72,7 @@ When `jest` is running in watch mode, the following special behavior applies:
 
 ## For Windows
 
-`jest-audio-reporter` using [`play-sound`](https://www.npmjs.com/package/play-sound) internally.
+`jest-audio-reporter` uses [`play-sound`](https://www.npmjs.com/package/play-sound) internally.
 For Windows, you will need to install [`mplayer`](https://www.mplayerhq.hu/).
 
 ## Audio Copyright Disclaimer

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   'reporters': [
     'default',
-    '<rootDir>/dist/index.js'
+    ['<rootDir>/dist/index.js', { volume: 0.3 }]
   ],
   'roots': [
     '<rootDir>/src'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1054,6 +1054,15 @@
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
+    "caller-id": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
+      "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
+      "dev": true,
+      "requires": {
+        "stack-trace": "~0.0.7"
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -6190,6 +6199,15 @@
         }
       }
     },
+    "mock-require": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
+      "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
+      "dev": true,
+      "requires": {
+        "caller-id": "^0.1.0"
+      }
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -11070,6 +11088,12 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
     "stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -11525,6 +11549,15 @@
             "tslib": "^1.8.1"
           }
         }
+      }
+    },
+    "tslint-language-service": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/tslint-language-service/-/tslint-language-service-0.9.9.tgz",
+      "integrity": "sha1-9UbcOEg5eeb7PPpZWErYUls61No=",
+      "dev": true,
+      "requires": {
+        "mock-require": "^2.0.2"
       }
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ts-jest": "^23.10.4",
     "tslint": "^5.11.0",
     "tslint-config-unional": "^0.10.0",
+    "tslint-language-service": "^0.9.9",
     "typescript": "^3.1.3"
   }
 }

--- a/src/AudioReporter.spec.ts
+++ b/src/AudioReporter.spec.ts
@@ -44,7 +44,6 @@ test('Will play onStart if there is no estimate', () => {
   o.end()
 })
 
-
 test('pick one if onStart has more than one entry', () => {
   const subject = new AudioReporter(gc(), {})
   subject.options = runtimeOptions({
@@ -210,6 +209,114 @@ test('when debug = false, log is not enabled', () => {
   t.strictEqual(subject.log.enabled, false)
 })
 
+test('lower master volume in OSX affect onStart', () => {
+  const subject = new AudioReporter(gc(), { volume: 0.5 })
+  let actual
+  subject.player = { player: 'afplay', play(_file, option) { actual = option } }
+
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  t.deepStrictEqual(actual, { afplay: ['-v', 0.1] })
+})
+
+test('lower master volume in OSX affect onComplete', () => {
+  const subject = new AudioReporter(gc(), { volume: 0.5 })
+  let actual
+  subject.player = { player: 'afplay', play(_file, option) { actual = option } }
+
+  subject.onRunComplete(undefined, ar({ numTotalTestSuites: 1 }))
+  t.deepStrictEqual(actual, { afplay: ['-v', 0.1] })
+})
+
+test('lower master volume in Windows affect onStart', () => {
+  const subject = new AudioReporter(gc(), { volume: 0.5 })
+  let actual
+  subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
+
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  t.deepStrictEqual(actual, { mplayer: ['-volume', 50] })
+})
+
+test('lower master volume in Windows affect onComplete', () => {
+  const subject = new AudioReporter(gc(), { volume: 0.5 })
+  let actual
+  subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
+
+  subject.onRunComplete(undefined, ar({ numTotalTestSuites: 1 }))
+  t.deepStrictEqual(actual, { mplayer: ['-volume', 50] })
+})
+
+test('lower onStartVolume in OSX affect onStart', () => {
+  const subject = new AudioReporter(gc(), { onStartVolume: 0.5 })
+  let actual
+  subject.player = { player: 'afplay', play(_file, option) { actual = option } }
+
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  t.deepStrictEqual(actual, { afplay: ['-v', 0.1] })
+})
+
+test('lower onStartVolume in OSX will not affect onComplete', () => {
+  const subject = new AudioReporter(gc(), { onStartVolume: 0.5 })
+  let actual
+  subject.player = { player: 'afplay', play(_file, option) { actual = option } }
+
+  subject.onRunComplete(undefined, ar({ numTotalTestSuites: 1 }))
+  t.deepStrictEqual(actual, { afplay: ['-v', 1] })
+})
+
+test('lower onStartVolume in Windows affect onStart', () => {
+  const subject = new AudioReporter(gc(), { onStartVolume: 0.5 })
+  let actual
+  subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
+
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  t.deepStrictEqual(actual, { mplayer: ['-volume', 50] })
+})
+
+test('lower onStartVolume in Windows will not affect onComplete', () => {
+  const subject = new AudioReporter(gc(), { onStartVolume: 0.5 })
+  let actual
+  subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
+
+  subject.onRunComplete(undefined, ar({ numTotalTestSuites: 1 }))
+  t.deepStrictEqual(actual, { mplayer: ['-volume', 100] })
+})
+
+test('lower onCompleteVolume in OSX will not affect onStart', () => {
+  const subject = new AudioReporter(gc(), { onCompleteVolume: 0.5 })
+  let actual
+  subject.player = { player: 'afplay', play(_file, option) { actual = option } }
+
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  t.deepStrictEqual(actual, { afplay: ['-v', 1] })
+})
+
+test('lower onCompleteVolume in OSX affect onComplete', () => {
+  const subject = new AudioReporter(gc(), { onCompleteVolume: 0.5 })
+  let actual
+  subject.player = { player: 'afplay', play(_file, option) { actual = option } }
+
+  subject.onRunComplete(undefined, ar({ numTotalTestSuites: 1 }))
+  t.deepStrictEqual(actual, { afplay: ['-v', 0.1] })
+})
+
+test('lower onCompleteVolume in Windows will not affect onStart', () => {
+  const subject = new AudioReporter(gc(), { onCompleteVolume: 0.5 })
+  let actual
+  subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
+
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  t.deepStrictEqual(actual, { mplayer: ['-volume', 100] })
+})
+
+test('lower onCompleteVolume in Windows affect onComplete', () => {
+  const subject = new AudioReporter(gc(), { onCompleteVolume: 0.5 })
+  let actual
+  subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
+
+  subject.onRunComplete(undefined, ar({ numTotalTestSuites: 1 }))
+  t.deepStrictEqual(actual, { mplayer: ['-volume', 50] })
+})
+
 function gc(config: Partial<jest.GlobalConfig> = {}) {
   return config as jest.GlobalConfig
 }
@@ -218,6 +325,9 @@ function ar(results: Partial<jest.AggregatedResult> = {}) {
   return results as jest.AggregatedResult
 }
 
+function roso(options: Partial<jest.ReporterOnStartOptions> = {}) {
+  return options as jest.ReporterOnStartOptions
+}
 
 function runtimeOptions(options: Partial<RuntimeOptions>) {
   return {

--- a/src/AudioReporter.spec.ts
+++ b/src/AudioReporter.spec.ts
@@ -12,7 +12,7 @@ test('Will not play onSuitePass if no test ran', () => {
   subject.onRunComplete({}, ar({ numTotalTestSuites: 0 }))
 })
 
-test.only('Will not play onStart if test estimated to take less than 10s to run', () => {
+test('Will not play onStart if test estimated to take less than 10s to run', () => {
   const subject = new AudioReporter(gc(), {})
   subject.options = runtimeOptions({
     onSuitePass: ['audio/onSuitePass/昇格.mp3']

--- a/src/AudioReporter.spec.ts
+++ b/src/AudioReporter.spec.ts
@@ -12,23 +12,23 @@ test('Will not play onSuitePass if no test ran', () => {
   subject.onRunComplete({}, ar({ numTotalTestSuites: 0 }))
 })
 
-test('Will not play onStart if test estimated to take less than 3s to run', () => {
+test.only('Will not play onStart if test estimated to take less than 10s to run', () => {
   const subject = new AudioReporter(gc(), {})
   subject.options = runtimeOptions({
     onSuitePass: ['audio/onSuitePass/昇格.mp3']
   })
 
   subject.player = { play() { throw new Error('should not play') } }
-  subject.onRunStart(ar(), { estimatedTime: 3, showStatus: false })
+  subject.onRunStart(ar(), { estimatedTime: 10, showStatus: false })
 })
 
-test('Will play onStart if test estimated to take more than 3s to run', () => {
+test('Will play onStart if test estimated to take more than 10s to run', () => {
   const subject = new AudioReporter(gc(), {})
   subject.options = runtimeOptions({ onSuitePass: ['audio/onSuitePass/昇格.mp3'] })
 
   const o = new AssertOrder(1)
   subject.player = { play() { o.once(1) } }
-  subject.onRunStart(ar(), { estimatedTime: 3.01, showStatus: false })
+  subject.onRunStart(ar(), { estimatedTime: 10.01, showStatus: false })
 
   o.end()
 })
@@ -57,7 +57,7 @@ test('pick one if onStart has more than one entry', () => {
     }
   }
   for (let i = 0; i < 100; i++)
-    subject.onRunStart(ar(), { estimatedTime: 3.01, showStatus: false })
+    subject.onRunStart(ar(), { estimatedTime: 10.01, showStatus: false })
 
   t(calls[0] * calls[1] > 0)
 })
@@ -159,7 +159,7 @@ describe('watch mode', () => {
 
     const o = new AssertOrder(1)
     subject.player = { play() { return { kill() { o.once(1) } } } }
-    subject.onRunStart(ar(), { estimatedTime: 4, showStatus: false })
+    subject.onRunStart(ar(), { estimatedTime: 11, showStatus: false })
     subject.onRunComplete({}, ar())
     o.end()
   })
@@ -174,7 +174,7 @@ describe('watch mode', () => {
     const o = new AssertOrder(1)
     subject.player = { play() { return { kill() { o.once(1) } } } }
     subject.onRunComplete({}, ar({ numTotalTestSuites: 1, numFailedTestSuites: 0 }))
-    subject.onRunStart(ar(), { estimatedTime: 4, showStatus: false })
+    subject.onRunStart(ar(), { estimatedTime: 11, showStatus: false })
     o.end()
   })
   test('kill onSuiteFailure when run starts', () => {
@@ -188,7 +188,7 @@ describe('watch mode', () => {
     const o = new AssertOrder(1)
     subject.player = { play() { return { kill() { o.once(1) } } } }
     subject.onRunComplete({}, ar({ numTotalTestSuites: 1, numFailedTestSuites: 1 }))
-    subject.onRunStart(ar(), { estimatedTime: 4, showStatus: false })
+    subject.onRunStart(ar(), { estimatedTime: 11, showStatus: false })
     o.end()
   })
 })
@@ -214,7 +214,7 @@ test('lower master volume in OSX affect onStart', () => {
   let actual
   subject.player = { player: 'afplay', play(_file, option) { actual = option } }
 
-  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 11 }))
   t.deepStrictEqual(actual, { afplay: ['-v', 0.1] })
 })
 
@@ -232,7 +232,7 @@ test('lower master volume in Windows affect onStart', () => {
   let actual
   subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
 
-  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 11 }))
   t.deepStrictEqual(actual, { mplayer: ['-volume', 50] })
 })
 
@@ -250,7 +250,7 @@ test('lower onStartVolume in OSX affect onStart', () => {
   let actual
   subject.player = { player: 'afplay', play(_file, option) { actual = option } }
 
-  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 11 }))
   t.deepStrictEqual(actual, { afplay: ['-v', 0.1] })
 })
 
@@ -268,7 +268,7 @@ test('lower onStartVolume in Windows affect onStart', () => {
   let actual
   subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
 
-  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 11 }))
   t.deepStrictEqual(actual, { mplayer: ['-volume', 50] })
 })
 
@@ -286,7 +286,7 @@ test('lower onCompleteVolume in OSX will not affect onStart', () => {
   let actual
   subject.player = { player: 'afplay', play(_file, option) { actual = option } }
 
-  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 11 }))
   t.deepStrictEqual(actual, { afplay: ['-v', 1] })
 })
 
@@ -304,7 +304,7 @@ test('lower onCompleteVolume in Windows will not affect onStart', () => {
   let actual
   subject.player = { player: 'mplayer', play(_file, option) { actual = option } }
 
-  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 10 }))
+  subject.onRunStart(ar({ numTotalTestSuites: 1 }), roso({ estimatedTime: 11 }))
   t.deepStrictEqual(actual, { mplayer: ['-volume', 100] })
 })
 
@@ -334,7 +334,7 @@ function runtimeOptions(options: Partial<RuntimeOptions>) {
     onStart: [],
     onSuitePass: [],
     onSuiteFailure: [],
-    onStartThreshold: 3,
+    onStartThreshold: 10,
     ...options
   }
 }

--- a/src/AudioReporter.ts
+++ b/src/AudioReporter.ts
@@ -1,0 +1,116 @@
+import Player from 'play-sound';
+import { createLog, logOptions } from './log';
+import { processOptions, Options, rawRCOptions, RuntimeOptions } from './options';
+import { store } from './store';
+
+const player = Player({})
+const rcOptions = processOptions(rawRCOptions)
+
+export class AudioReporter {
+  log = createLog()
+  player = player
+  options: RuntimeOptions
+  volume: number | undefined
+  onStartVolume: number | undefined
+  onCompleteVolume: number | undefined
+  constructor(public globalConfig: jest.GlobalConfig, jestOptions: Partial<Options>) {
+    if (jestOptions.debug) {
+      this.log.enabled = true
+    }
+    this.volume = jestOptions.volume
+    this.onStartVolume = jestOptions.onStartVolume
+    this.onCompleteVolume = jestOptions.onCompleteVolume
+
+    logOptions({ log: this.log }, rawRCOptions, rcOptions)
+    this.options = rcOptions
+  }
+  onRunStart(results: jest.AggregatedResult, options: jest.ReporterOnStartOptions) {
+    if (store.completeAudio) {
+      store.completeAudio.kill()
+      store.completeAudio = undefined
+    }
+
+    if (results.numTotalTestSuites === 0 ||
+      options.estimatedTime > 0 &&
+      options.estimatedTime <= this.options.onStartThreshold) return
+
+    const file = pickOne(this.options.onStart)
+    const volume = this.getEffectiveOnStartVolume()
+    store.startAudio = this.player.play(file, this.getPlayOption({ volume }))
+  }
+  onRunComplete(_contexts, results: jest.AggregatedResult) {
+    if (store.startAudio) {
+      store.startAudio.kill()
+      store.startAudio = undefined
+    }
+    if (results.numTotalTestSuites === 0) return
+    if (results.wasInterrupted) return
+
+    if (results.numFailedTestSuites === 0) {
+      if (isWatch(this.globalConfig) && store.doesLastRunPass) return
+      store.doesLastRunPass = true
+      return this.playComplete(pickOne(this.options.onSuitePass))
+    }
+    else {
+      store.doesLastRunPass = false
+      return this.playComplete(pickOne(this.options.onSuiteFailure))
+    }
+  }
+  private playComplete(file: string | undefined) {
+    if (!file) return
+    const volume = this.getEffectiveOnCompleteVolume()
+    if (isWatch(this.globalConfig)) {
+      store.completeAudio = this.player.play(file, this.getPlayOption({ volume }))
+    }
+    else {
+      return new Promise(a => {
+        store.completeAudio = this.player.play(file, this.getPlayOption({ volume }), a)
+      })
+    }
+  }
+  private getEffectiveOnStartVolume() {
+    return Math.min(this.volume || 1, this.onStartVolume || 1)
+  }
+  private getEffectiveOnCompleteVolume() {
+    return Math.min(this.volume || 1, this.onCompleteVolume || 1)
+  }
+  private getPlayOption(option) {
+    switch (this.player.player) {
+      case 'afplay':
+        return getAfPlayOption(option)
+      case 'mplayer':
+        return getMplayerOption(option)
+      default:
+        return {}
+    }
+  }
+}
+
+function pickOne(arr: Array<any>) {
+  if (arr.length === 0) return undefined
+  return arr[Math.floor(Math.random() * arr.length)]
+}
+
+function isWatch(globalConfig) {
+  return globalConfig.watch || globalConfig.watchAll
+}
+
+function getAfPlayOption({ volume }: { volume: number | undefined }) {
+  if (volume === undefined) return {}
+
+  // https://ss64.com/osx/afplay.html
+  // According to the link, the volume is logarithmic,
+  // but I'm not sure what does it mean, as:
+  // log(1) = 0
+  // log(0.1) = -1
+  // log(0) = -infinity
+  // So for now, I treat [0, 1] as linear
+  return { afplay: ['-v', 1 / (Math.pow(10, Math.log2(1 / volume)))] }
+}
+
+function getMplayerOption({ volume }: { volume: number | undefined }) {
+  if (volume === undefined) return {}
+
+  // http://www.mplayerhq.hu/DOCS/man/en/mplayer.1.html search for "-volume"
+  return { mplayer: ['-volume', volume * 100] }
+}

--- a/src/AudioReporter.ts
+++ b/src/AudioReporter.ts
@@ -95,9 +95,7 @@ function isWatch(globalConfig) {
   return globalConfig.watch || globalConfig.watchAll
 }
 
-function getAfPlayOption({ volume }: { volume: number | undefined }) {
-  if (volume === undefined) return {}
-
+function getAfPlayOption({ volume }: { volume: number }) {
   // https://ss64.com/osx/afplay.html
   // According to the link, the volume is logarithmic,
   // but I'm not sure what does it mean, as:
@@ -108,9 +106,7 @@ function getAfPlayOption({ volume }: { volume: number | undefined }) {
   return { afplay: ['-v', 1 / (Math.pow(10, Math.log2(1 / volume)))] }
 }
 
-function getMplayerOption({ volume }: { volume: number | undefined }) {
-  if (volume === undefined) return {}
-
+function getMplayerOption({ volume }: { volume: number }) {
   // http://www.mplayerhq.hu/DOCS/man/en/mplayer.1.html search for "-volume"
   return { mplayer: ['-volume', volume * 100] }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,4 @@
-import Player from 'play-sound';
-import { createLog, logOptions } from './log';
-import { processOptions, Options, rawRCOptions, RuntimeOptions } from './options';
 import { store } from './store';
-
-const player = Player({})
-const rcOptions = processOptions(rawRCOptions)
 
 // istanbul ignore next
 process.on('exit', () => {
@@ -12,66 +6,6 @@ process.on('exit', () => {
   if (store.completeAudio) store.completeAudio.kill()
 })
 
-export = class AudioReporter {
-  log = createLog()
-  player = player
-  options: RuntimeOptions
-  constructor(public globalConfig: jest.GlobalConfig, jestOptions: Partial<Options>) {
-    if (jestOptions.debug) {
-      this.log.enabled = true
-    }
-    logOptions({ log: this.log }, rawRCOptions, rcOptions)
-    this.options = rcOptions
-  }
-  onRunStart(results: jest.AggregatedResult, options: jest.ReporterOnStartOptions) {
-    if (store.completeAudio) {
-      store.completeAudio.kill()
-      store.completeAudio = undefined
-    }
+import { AudioReporter } from './AudioReporter'
 
-    if (results.numTotalTestSuites === 0 ||
-      options.estimatedTime > 0 &&
-      options.estimatedTime <= this.options.onStartThreshold) return
-
-    const file = pickOne(this.options.onStart)
-    store.startAudio = this.player.play(file)
-  }
-  onRunComplete(_contexts, results: jest.AggregatedResult) {
-    if (store.startAudio) {
-      store.startAudio.kill()
-      store.startAudio = undefined
-    }
-    if (results.numTotalTestSuites === 0) return
-    if (results.wasInterrupted) return
-
-    if (results.numFailedTestSuites === 0) {
-      if (isWatch(this.globalConfig) && store.doesLastRunPass) return
-      store.doesLastRunPass = true
-      return this.playComplete(pickOne(this.options.onSuitePass))
-    }
-    else {
-      store.doesLastRunPass = false
-      return this.playComplete(pickOne(this.options.onSuiteFailure))
-    }
-  }
-  private playComplete(file: string | undefined) {
-    if (!file) return
-    if (isWatch(this.globalConfig)) {
-      store.completeAudio = this.player.play(file)
-    }
-    else {
-      return new Promise(a => {
-        store.completeAudio = this.player.play(file, a)
-      })
-    }
-  }
-}
-
-function pickOne(arr: Array<any>) {
-  if (arr.length === 0) return undefined
-  return arr[Math.floor(Math.random() * arr.length)]
-}
-
-function isWatch(globalConfig) {
-  return globalConfig.watch || globalConfig.watchAll
-}
+export = AudioReporter

--- a/src/options.spec.ts
+++ b/src/options.spec.ts
@@ -15,9 +15,9 @@ describe('processOptions', () => {
       onStartThreshold: 4
     })
   })
-  test('onStartThreshold is default to 3', () => {
+  test('onStartThreshold is default to 10', () => {
     a.satisfy(processOptions({}), {
-      onStartThreshold: 3
+      onStartThreshold: 10
     })
   })
   test('simple string is convert to entry in array', () => {

--- a/src/options.ts
+++ b/src/options.ts
@@ -40,7 +40,7 @@ export function processOptions(rawRCOptions) {
   const onSuitePass = processRCFileEntry(rawRCOptions.onSuitePass, dirs)
   const onSuiteFailure = processRCFileEntry(rawRCOptions.onSuiteFailure, dirs)
 
-  const onStartThreshold = rawRCOptions.onStartThreshold !== undefined ? parseInt(rawRCOptions.onStartThreshold, 10) : 3
+  const onStartThreshold = rawRCOptions.onStartThreshold !== undefined ? parseInt(rawRCOptions.onStartThreshold, 10) : 10
 
   return {
     onStartThreshold,

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,11 +3,25 @@ import path from 'path';
 import rc from 'rc';
 
 export interface Options {
+  /**
+   * Enable debug mode.
+   */
   debug: boolean,
-  onStart: string | string[],
-  onStartThreshold: number,
-  onSuitePass: string | string[],
-  onSuiteFailure: string | string[]
+  /**
+   * Master volume. 0 (silent) - 1 (normal).
+   */
+  volume: number
+  /**
+   * Volume for onStart. 0 (silent) - 1 (normal).
+   * Value higher than Master volume is ignored.
+   */
+  onStartVolume: number
+
+  /**
+   * Volume for onPass and onFailure. 0 (silent) - 1 (normal).
+   * Value higher than Master volume is ignored.
+   */
+  onCompleteVolume: number
 }
 
 export interface RuntimeOptions {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,13 @@
   },
   "buildOnSave": false,
   "compileOnSave": false,
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "tslint-language-service"
+      }
+    ]
+  },
   "include": [
     "src"
   ]


### PR DESCRIPTION
feat: adjust default `onStartThreshold` from 3 seconds to 10 seconds

NOTE: volume support only works in OSX and Windows. PR welcome for other platforms.